### PR TITLE
fixed crash because "debug" is not defined

### DIFF
--- a/script.py
+++ b/script.py
@@ -63,9 +63,6 @@ with open(sourceFile, "w") as file:
                 
                 output = 'M117 ' + parsed[1] + '% ' + time_math + " left"
 
-                if debug >= 2:
-                    print(f"converted {stringMatch} to {output}")
-
                 # save new line to file
                 file.write(f"{output}\n")
 


### PR DESCRIPTION
The script crashed with error:

```
Traceback (most recent call last):
  File "blablabla.py", line 66, in <module>
    if debug >= 2:
NameError: name 'debug' is not defined
```
I fixed the bug